### PR TITLE
Fix/ressource leak

### DIFF
--- a/Overlaps.cpp
+++ b/Overlaps.cpp
@@ -24165,14 +24165,19 @@ char* output_file_name, ma_hit_t_alloc** reverse_sources, R_to_U* ruIndex)
     char* gfa_name = (char*)malloc(strlen(output_file_name)+55);
     sprintf(gfa_name, "%s.all.debug.source.bin", output_file_name);
     fp = fopen(gfa_name, "r"); if(!fp) return 0;
+    fclose(fp); /* Prevent ressource leak.*/
     sprintf(gfa_name, "%s.all.debug.reverse.bin", output_file_name);
     fp = fopen(gfa_name, "r"); if(!fp) return 0;
+    fclose(fp); /* Prevent ressource leak.*/
     sprintf(gfa_name, "%s.all.debug.coverage_cut.bin", output_file_name);
     fp = fopen(gfa_name, "r"); if(!fp) return 0;
+    fclose(fp); /* Prevent ressource leak.*/
     sprintf(gfa_name, "%s.all.debug.ruIndex.bin", output_file_name);
     fp = fopen(gfa_name, "r"); if(!fp) return 0;
+    fclose(fp); /* Prevent ressource leak.*/
     sprintf(gfa_name, "%s.all.debug.asg_t.bin", output_file_name);
     fp = fopen(gfa_name, "r"); if(!fp) return 0;
+    fclose(fp); /* Prevent ressource leak.*/
     if((sg == NULL) || (sources == NULL) || (coverage_cut == NULL) || (reverse_sources == NULL) || 
         (ruIndex == NULL))
     {

--- a/Trio.cpp
+++ b/Trio.cpp
@@ -86,7 +86,7 @@ static yak_ch_t *yak_ch_restore_core(yak_ch_t *ch0, const char *fn, int mode, ..
 	if (mode_err) return 0;
 
 	if ((fp = fopen(fn, "rb")) == 0) return 0;
-	if (fread(magic, 1, 4, fp) != 4) return 0;
+	if (fread(magic, 1, 4, fp) != 4) { fclose(fp); return 0; }
 	if (strncmp(magic, YAK_MAGIC, 4) != 0) {
 		fprintf(stderr, "ERROR: wrong file magic.\n");
 		fclose(fp);


### PR DESCRIPTION
Some files were opened but never closed. This causes a resource leaks, which can be problematic in long running processes such as hifiasm, and even can cause security problems.
Here, it should not change anything, but is still removes warnings.