### PR TITLE
Makefile: add LDFLAGS variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 all:$(EXE)
 
 $(EXE):$(OBJS) main.o
-		$(CXX) $(CXXFLAGS) $^ -o $@ $(LIBS)
+		$(CXX) $(CXXFLAGS) $(LDFLAGS) $^ -o $@ $(LIBS)
 
 clean:
 		rm -fr gmon.out *.o a.out $(EXE) *~ *.a *.dSYM


### PR DESCRIPTION
I am attempting to package hifiasm on behalf of [bioarchlinux ](https://github.com/BioArchLinux/Packages)project. in the process i found that the resulting binary from default `Makefile` lacks [RELRO](https://wiki.archlinux.org/title/Arch_package_guidelines/Security#RELRO) mitigation. Archlinux as well as other linux distros strongly recommend RELRO mitigation be applied. 

the following patch adds `$(LDFLAGS)` variable support to the Makefile so that distro packagers can build hifiasm without resorting to manually patching Makefile

