### PR TITLE
Support for direct input of unaligned BAM files – no fastq conversion required

### DIFF
--- a/CommandLines.cpp
+++ b/CommandLines.cpp
@@ -238,7 +238,7 @@ void Print_H(hifiasm_opt_t* asm_opt)
 
 
     fprintf(stderr, "Example: ./hifiasm -o NA12878.asm -t 32 NA12878.fq.gz\n");
-    fprintf(stderr, "         ./hifiasm -o NA12878.asm -t 32 NA12878.subreads.unaligned.bam\n");
+    fprintf(stderr, "         ./hifiasm -o NA12878.asm -t 32 NA12878.hifi_reads.bam\n");
     fprintf(stderr, "See `https://hifiasm.readthedocs.io/en/latest/' or `man ./hifiasm.1' for complete documentation.\n");
 }
 

--- a/CommandLines.cpp
+++ b/CommandLines.cpp
@@ -8,6 +8,7 @@
 #include "CommandLines.h"
 #include "ketopt.h"
 #include "kseq.h"
+#include "seq_reader.h"
 
 KSEQ_INIT(gzFile, gzread)
 
@@ -94,7 +95,7 @@ double Get_T(void)
 
 void Print_H(hifiasm_opt_t* asm_opt)
 {
-    fprintf(stderr, "Usage: hifiasm [options] <in_1.fq> <in_2.fq> <...>\n");
+    fprintf(stderr, "Usage: hifiasm [options] <in_1.[fa|fq|bam]> <in_2.[fa|fq|bam]> <...>\n");
     fprintf(stderr, "Options:\n");
 	fprintf(stderr, "  Input/Output:\n");
     fprintf(stderr, "    -o STR       prefix of output files [%s]\n", asm_opt->output_file_name);
@@ -237,6 +238,7 @@ void Print_H(hifiasm_opt_t* asm_opt)
 
 
     fprintf(stderr, "Example: ./hifiasm -o NA12878.asm -t 32 NA12878.fq.gz\n");
+    fprintf(stderr, "         ./hifiasm -o NA12878.asm -t 32 NA12878.subreads.unaligned.bam\n");
     fprintf(stderr, "See `https://hifiasm.readthedocs.io/en/latest/' or `man ./hifiasm.1' for complete documentation.\n");
 }
 
@@ -765,27 +767,27 @@ void get_queries(int argc, char *argv[], ketopt_t* opt, hifiasm_opt_t* asm_opt)
     asm_opt->read_file_names = (char**)malloc(sizeof(char*)*asm_opt->num_reads);
     
     long long i; int ret;
-    gzFile dfp; kseq_t *ks = NULL;
+    ha_seq_reader_t sr;
     for (i = 0; i < asm_opt->num_reads; i++) {
         asm_opt->read_file_names[i] = argv[i + opt->ind];
-        dfp = gzopen(asm_opt->read_file_names[i], "r");
-        if (dfp == 0) {
-            fprintf(stderr, "[ERROR] Cannot find the input read file: %s\n", 
-                    asm_opt->read_file_names[i]);
-		    exit(0);
+        if (!ha_seq_open(&sr, asm_opt->read_file_names[i])) {
+            fprintf(stderr, "[ERROR] %s\n", ha_seq_error(&sr));
+            exit(0);
         } else if(asm_opt->is_sc){
-            ks = kseq_init(dfp);
-            while (((ret = kseq_read(ks)) >= 0)) {
-                if((ks->qual.l == 0) || (ks->qual.s == NULL)) {
-                    fprintf(stderr, "[ERROR] %s is in fasta format rather than fastq format\n", asm_opt->read_file_names[i]);
-                    asm_opt->is_sc = 0;
-                    exit(0);
-                }
-                break;
+            ret = ha_seq_read(&sr);
+            if (ret == -2) {
+                fprintf(stderr, "[ERROR] %s (%s)\n", ha_seq_error(&sr), asm_opt->read_file_names[i]);
+                ha_seq_close(&sr);
+                exit(0);
             }
-            kseq_destroy(ks); ks = NULL;
+            if(ret >= 0 && ((sr.rec.qual.l == 0) || (sr.rec.qual.s == NULL))) {
+                fprintf(stderr, "[ERROR] %s does not contain qualities required for fastq-style input\n", asm_opt->read_file_names[i]);
+                asm_opt->is_sc = 0;
+                ha_seq_close(&sr);
+                exit(0);
+            }
         }
-        gzclose(dfp);
+        ha_seq_close(&sr);
     }
 }
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ INCLUDES=
 OBJS=		CommandLines.o Process_Read.o Assembly.o Hash_Table.o \
 			POA.o Correct.o Levenshtein_distance.o Overlaps.o Trio.o kthread.o Purge_Dups.o \
 			htab.o hist.o sketch.o anchor.o extract.o sys.o hic.o rcut.o horder.o ecovlp.o\
-			tovlp.o inter.o kalloc.o gfa_ut.o gchain_map.o
+			tovlp.o inter.o kalloc.o gfa_ut.o gchain_map.o seq_reader.o
 EXE=		hifiasm
 LIBS=		-lz -lpthread -lm
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,10 @@ Its latest release could support the telomere-to-telomere assembly by utilizing 
 A typical hifiasm command line looks like:
 ```sh
 hifiasm -o NA12878.asm -t 32 NA12878.fq.gz
+# or
+hifiasm -o NA12878.asm -t 32 NA12878.hifi_reads.bam
 ```
-where `NA12878.fq.gz` provides the input reads, `-t` sets the number of CPUs in
+where `NA12878.fq.gz` or `NA12878.hifi_reads.bam` provides the input reads, `-t` sets the number of CPUs in
 use and `-o` specifies the prefix of output files. The primary HiFi input may
 also be provided as native unaligned PacBio BAM. FASTA/FASTQ inputs may be plain
 text or gzip-compressed. For BAM input, hifiasm accepts unaligned records

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ wget https://github.com/chhylp123/hifiasm/releases/download/v0.7/chr11-2M.fa.gz
 ./hifiasm -o test -t4 -f0 chr11-2M.fa.gz 2> test.log
 awk '/^S/{print ">"$2;print $3}' test.bp.p_ctg.gfa > test.p_ctg.fa  # get primary contigs in FASTA
 
+# Run directly on PacBio unaligned bam files
+hifiasm -o HG002.asm -t32 HG002.hifi_reads.bam
+
 # Assemble inbred/homozygous genomes (-l0 disables duplication purging)
 hifiasm -o CHM13.asm -t32 -l0 CHM13-HiFi.fa.gz 2> CHM13.asm.log
 # Assemble heterozygous genomes with built-in duplication purging

--- a/README.md
+++ b/README.md
@@ -95,7 +95,10 @@ A typical hifiasm command line looks like:
 hifiasm -o NA12878.asm -t 32 NA12878.fq.gz
 ```
 where `NA12878.fq.gz` provides the input reads, `-t` sets the number of CPUs in
-use and `-o` specifies the prefix of output files. For this example, the
+use and `-o` specifies the prefix of output files. The primary HiFi input may
+also be provided as native unaligned PacBio BAM. FASTA/FASTQ inputs may be plain
+text or gzip-compressed. For BAM input, hifiasm accepts unaligned records
+directly without FASTQ conversion. For this example, the
 primary contigs are written to `NA12878.asm.bp.p_ctg.gfa`. 
 Since v0.15, hifiasm also produces two sets of
 partially phased contigs at `NA12878.asm.bp.hap?.p_ctg.gfa`. This pair of files

--- a/docs/source/pa-assembly.rst
+++ b/docs/source/pa-assembly.rst
@@ -9,8 +9,9 @@ A typical hifiasm command line looks like::
  hifiasm -o NA12878.asm -t 32 NA12878.fq.gz
 
 where ``NA12878.fq.gz`` provides the input reads, ``-t`` sets the number of CPUs in
-use and ``-o`` specifies the prefix of output files. Input sequences should be FASTA 
-or FASTQ format, uncompressed or compressed with gzip (.gz). The quality scores of reads 
+use and ``-o`` specifies the prefix of output files. Primary HiFi inputs can be FASTA,
+FASTQ, or native unaligned PacBio BAM. FASTA/FASTQ inputs may be uncompressed or
+compressed with gzip (.gz). The quality scores of reads
 in FASTQ are ignored by hifiasm. Hifiasm outputs assemblies in `GFA <https://github.com/pmelsted/GFA-spec/blob/master/GFA-spec.md>`_ format.
 
 At the first run, hifiasm saves corrected reads and overlaps to disk as ``NA12878.asm.*.bin``. It reuses the saved results to avoid the time-consuming all-vs-all overlap calculation next time. You may specify ``-i`` to ignore precomputed overlaps and redo overlapping from raw reads. You can also dump error corrected reads in FASTA and read overlaps in PAF with::
@@ -44,4 +45,3 @@ To get primary/alternate assemblies, the option ``--primary`` should be set::
 
 The primary contigs and the alternate contigs are written to ``NA12878.asm.p_ctg.gfa`` and ``NA12878.asm.a_ctg.gfa``, respectively. For inbred or homozygous genomes, the primary/alternate assemblies can be also produced by ``-l0``. Similarly, turning ``-s`` or ``--hom-cov`` should 
 be helpful if the primary assembly is too large. See :ref:`p-large` for more details.
-

--- a/docs/source/parameter-reference.rst
+++ b/docs/source/parameter-reference.rst
@@ -10,7 +10,7 @@ Synopsis
 Assembly only with HiFi reads:
 ::
 
-  hifiasm -o [prefix] -t [nThreads] [options] input1.fq [input2.fq [...]]
+  hifiasm -o [prefix] -t [nThreads] [options] input1.fq|input1.fa|input1.bam [input2 [...]]
 
 Trio binning assembly with yak dumps:
 ::

--- a/hifiasm.1
+++ b/hifiasm.1
@@ -61,7 +61,8 @@ hifiasm - haplotype-resolved de novo assembler for PacBio Hifi reads.
 Hifiasm is an ultrafast haplotype-resolved de novo assembler for PacBio
 Hifi reads. Unlike most existing assemblers, hifiasm starts from uncollapsed
 genome. Thus, it is able to keep the haplotype information as much as possible.
-The input of hifiasm is the PacBio Hifi reads in fasta/fastq format, and its
+The input of hifiasm is the PacBio Hifi reads in fasta/fastq format or native
+unaligned PacBio BAM, and its
 outputs consist of multiple types of assembly graphs in GFA format.
 
 

--- a/htab.cpp
+++ b/htab.cpp
@@ -9,6 +9,7 @@
 #include "ksort.h"
 #include "htab.h"
 #include "Process_Read.h"
+#include "seq_reader.h"
 
 #define YAK_COUNTER_BITS 12
 #define YAK_N_COUNTS     (1<<YAK_COUNTER_BITS)
@@ -580,7 +581,7 @@ typedef struct { // global data structure for kt_pipeline()
 	const void *flt_tab;
 	int flag, create_new, is_store, uq;
 	uint64_t n_mz, n_seq; ///number of total reads
-	kseq_t *ks;
+	ha_seq_reader_t *sr;
 	UC_Read ucr;
 	ha_ct_t *ct;
 	ha_pt_t *pt;
@@ -758,10 +759,10 @@ static void *sf##_worker_count(void *data, int step, void *in) /** callback for 
 					break;\
 			}\
 		} else {\
-			while ((ret = kseq_read(p->ks)) >= 0) {\
-				int l = (int)(p->ks->seq.l) - (int)(p->opt->adaLen) - (int)(p->opt->adaLen);\
+			while ((ret = ha_seq_read(p->sr)) >= 0) {\
+				int l = (int)(p->sr->rec.seq.l) - (int)(p->opt->adaLen) - (int)(p->opt->adaLen);\
 				if((l <= 0) || (l < asm_opt.rl_cut)) continue;\
-				if((asm_opt.is_sc) && (asm_opt.sc_cut > 0) && (!flt_quals(p->ks->qual.s+p->opt->adaLen, l, 33, asm_opt.sc_cut))) continue;\
+				if((asm_opt.is_sc) && (asm_opt.sc_cut > 0) && (!flt_quals(p->sr->rec.qual.s+p->opt->adaLen, l, 33, asm_opt.sc_cut))) continue;\
 				if (p->n_seq >= 1<<28) {\
 					fprintf(stderr, "ERROR: this implementation supports no more than %d reads\n", 1<<28);\
 					exit(1);\
@@ -770,20 +771,20 @@ static void *sf##_worker_count(void *data, int step, void *in) /** callback for 
 					/**for 0-th count, just insert read length to R_INF, instead of read**/\
 					if (p->flag & HAF_RS_WRITE_LEN) {\
 						assert(p->n_seq == p->rs_out->total_reads);\
-						ha_insert_read_len(p->rs_out, l, p->ks->name.l);\
+						ha_insert_read_len(p->rs_out, l, p->sr->rec.name.l);\
 					} else if (p->flag & HAF_RS_WRITE_SEQ) {\
 						int i, n_N;\
 						assert(l == (int)p->rs_out->read_length[p->n_seq]);\
 						for (i = n_N = 0; i < l; ++i) /** count number of ambiguous bases**/\
-							if (seq_nt4_table[(uint8_t)p->ks->seq.s[i+p->opt->adaLen]] >= 4)\
+							if (seq_nt4_table[(uint8_t)p->sr->rec.seq.s[i+p->opt->adaLen]] >= 4)\
 								++n_N;\
-						ha_compress_base(Get_READ(*p->rs_out, p->n_seq), p->ks->seq.s+p->opt->adaLen, l, &p->rs_out->N_site[p->n_seq], n_N);\
-						memcpy(&p->rs_out->name[p->rs_out->name_index[p->n_seq]], p->ks->name.s, p->ks->name.l);\
+						ha_compress_base(Get_READ(*p->rs_out, p->n_seq), p->sr->rec.seq.s+p->opt->adaLen, l, &p->rs_out->N_site[p->n_seq], n_N);\
+						memcpy(&p->rs_out->name[p->rs_out->name_index[p->n_seq]], p->sr->rec.name.s, p->sr->rec.name.l);\
 						if(p->rs_out->rsc) {\
-							ha_compress_qual(Get_QUAL(*p->rs_out, p->n_seq), p->ks->qual.s+p->opt->adaLen, l, sc_bn, 33);\
-							/**print_fastq(NULL, p->ks->name.s, p->ks->seq.s, p->ks->qual.s, (1<<sc_bn), 33);**/\
+							ha_compress_qual(Get_QUAL(*p->rs_out, p->n_seq), p->sr->rec.qual.s+p->opt->adaLen, l, sc_bn, 33);\
+							/**print_fastq(NULL, p->sr->rec.name.s, p->sr->rec.seq.s, p->sr->rec.qual.s, (1<<sc_bn), 33);**/\
 							/**if(l <= 1000000) {\
-								convert_qual(src_a, p->ks->qual.s+p->opt->adaLen, l, (1<<sc_bn), 0, 33);\
+								convert_qual(src_a, p->sr->rec.qual.s+p->opt->adaLen, l, (1<<sc_bn), 0, 33);\
 								retrive_bqual(NULL, des_a, p->n_seq, -1, -1, 0, sc_bn);\
 								if(memcmp(src_a, des_a, l)!=0) fprintf(stderr, "ERROR: incorrect qual values\n");\
 								else fprintf(stderr, "Correct: correct qual values\n");\
@@ -797,7 +798,7 @@ static void *sf##_worker_count(void *data, int step, void *in) /** callback for 
 					REALLOC(s->seq, s->m_seq);\
 				}\
 				MALLOC(s->seq[s->n_seq], l);\
-				memcpy(s->seq[s->n_seq], p->ks->seq.s+p->opt->adaLen, l);\
+				memcpy(s->seq[s->n_seq], p->sr->rec.seq.s+p->opt->adaLen, l);\
 				s->len[s->n_seq++] = l;\
 				++p->n_seq;\
 				s->sum_len += l;\
@@ -805,6 +806,10 @@ static void *sf##_worker_count(void *data, int step, void *in) /** callback for 
 				/**p->opt->chunk_size is the block max size**/\
 				if (s->sum_len >= p->opt->chunk_size)\
 					break;\
+			}\
+			if (ret == -2) {\
+				fprintf(stderr, "[ERROR] %s\n", ha_seq_error(p->sr));\
+				exit(1);\
 			}\
 		}\
 		if (s->sum_len == 0) free(s);\
@@ -933,7 +938,7 @@ static ha_ct_t *yak_count(const yak_copt_t *opt, const char *fn, int flag, ha_pt
 	int read_rs = (rs && (flag & HAF_RS_READ));
 	int ug_rs = (us && (flag & HAF_UG_READ));
 	pl_data_t pl;
-	gzFile fp = 0;
+	ha_seq_reader_t sr;
 	memset(&pl, 0, sizeof(pl_data_t));
 	pl.n_seq = *n_seq; 
 	if(ug_rs) {
@@ -942,8 +947,11 @@ static ha_ct_t *yak_count(const yak_copt_t *opt, const char *fn, int flag, ha_pt
 		pl.rs_in = rs;
 		init_UC_Read(&pl.ucr);
 	} else {///for 0-th counting, go into here
-		if ((fp = gzopen(fn, "r")) == 0) return 0;
-		pl.ks = kseq_init(fp);
+		if (!ha_seq_open(&sr, fn)) {
+			fprintf(stderr, "[ERROR] %s\n", ha_seq_error(&sr));
+			return 0;
+		}
+		pl.sr = &sr;
 	}
 	///for 0-th counting, read all reads into pl.rs_out
 	if (rs && (flag & (HAF_RS_WRITE_LEN|HAF_RS_WRITE_SEQ)))
@@ -972,8 +980,7 @@ static ha_ct_t *yak_count(const yak_copt_t *opt, const char *fn, int flag, ha_pt
 	if (read_rs) {
 		destory_UC_Read(&pl.ucr);
 	} else if(!read_rs && !ug_rs) {
-		kseq_destroy(pl.ks);
-		gzclose(fp);
+		ha_seq_close(&sr);
 	}
 	*n_seq = pl.n_seq;
 	if (pl.opt->w > 1) fprintf(stderr, "[M::%s] collected %ld minimizers\n", __func__, (long)pl.n_mz);

--- a/seq_reader.cpp
+++ b/seq_reader.cpp
@@ -1,0 +1,285 @@
+#include <zlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include "kseq.h"
+#include "seq_reader.h"
+
+KSEQ_INIT(gzFile, gzread)
+
+static void sr_set_error(ha_seq_reader_t *r, const char *msg)
+{
+	snprintf(r->err, sizeof(r->err), "%s", msg);
+}
+
+static void sr_set_error2(ha_seq_reader_t *r, const char *prefix, const char *fn)
+{
+	snprintf(r->err, sizeof(r->err), "%s%s", prefix, fn);
+}
+
+static int sr_gzread_exact(ha_seq_reader_t *r, void *buf, size_t len)
+{
+	size_t off = 0;
+	while (off < len) {
+		int ret = gzread(r->fp, (char *)buf + off, (unsigned int)(len - off));
+		if (ret <= 0) return 0;
+		off += ret;
+	}
+	return 1;
+}
+
+static uint32_t sr_le_u32(const uint8_t *p)
+{
+	return ((uint32_t)p[0]) | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static int32_t sr_le_i32(const uint8_t *p)
+{
+	return (int32_t)sr_le_u32(p);
+}
+
+static int sr_reserve(ha_sr_buf_t *b, size_t need)
+{
+	char *tmp;
+	if (b->m >= need) return 1;
+	b->m = need;
+	tmp = (char *)realloc(b->s, b->m);
+	if (!tmp) return 0;
+	b->s = tmp;
+	return 1;
+}
+
+static int sr_prepare_bam(ha_seq_reader_t *r)
+{
+	uint8_t hdr[8];
+	int32_t l_text, n_ref, i;
+	if (r->bam_header_ready) return 1;
+	if (!sr_gzread_exact(r, hdr, 4)) {
+		sr_set_error(r, "failed to read BAM magic");
+		return 0;
+	}
+	if (memcmp(hdr, "BAM\1", 4) != 0) {
+		sr_set_error(r, "input is not a BAM file");
+		return 0;
+	}
+	if (!sr_gzread_exact(r, hdr, 8)) {
+		sr_set_error(r, "failed to read BAM header");
+		return 0;
+	}
+	l_text = sr_le_i32(hdr);
+	n_ref = sr_le_i32(hdr + 4);
+	if (l_text < 0 || n_ref < 0) {
+		sr_set_error(r, "corrupted BAM header");
+		return 0;
+	}
+	if (l_text > 0) {
+		if (r->bam_buf_cap < (size_t)l_text) {
+			char *tmp = (char *)realloc(r->bam_buf, (size_t)l_text);
+			if (!tmp) {
+				sr_set_error(r, "out of memory while reading BAM header");
+				return 0;
+			}
+			r->bam_buf = tmp;
+			r->bam_buf_cap = (size_t)l_text;
+		}
+		if (!sr_gzread_exact(r, r->bam_buf, (size_t)l_text)) {
+			sr_set_error(r, "failed to read BAM text header");
+			return 0;
+		}
+	}
+	for (i = 0; i < n_ref; ++i) {
+		int32_t l_name;
+		if (!sr_gzread_exact(r, hdr, 4)) {
+			sr_set_error(r, "failed to read BAM reference header");
+			return 0;
+		}
+		l_name = sr_le_i32(hdr);
+		if (l_name <= 0) {
+			sr_set_error(r, "corrupted BAM reference name");
+			return 0;
+		}
+		if (r->bam_buf_cap < (size_t)l_name) {
+			char *tmp = (char *)realloc(r->bam_buf, (size_t)l_name);
+			if (!tmp) {
+				sr_set_error(r, "out of memory while reading BAM references");
+				return 0;
+			}
+			r->bam_buf = tmp;
+			r->bam_buf_cap = (size_t)l_name;
+		}
+		if (!sr_gzread_exact(r, r->bam_buf, (size_t)l_name) || !sr_gzread_exact(r, hdr, 4)) {
+			sr_set_error(r, "failed to read BAM reference entry");
+			return 0;
+		}
+	}
+	r->bam_header_ready = 1;
+	return 1;
+}
+
+static int sr_read_bam(ha_seq_reader_t *r)
+{
+	static const char bam_nt16_rev_table[16] = {
+		'N', 'A', 'C', 'N', 'G', 'N', 'N', 'N', 'T', 'N', 'N', 'N', 'N', 'N', 'N', 'N'
+	};
+	uint8_t core[36], *seq, *qual;
+	int32_t block_size, ref_id, pos, l_seq;
+	uint32_t bin_mq_nl, flag_nc, l_read_name, n_cigar, flag;
+	size_t seq_bytes, data_len, qual_off, i;
+	int ret = gzread(r->fp, core, 4);
+	if (ret == 0) return -1;
+	if (ret != 4 || !sr_gzread_exact(r, core + 4, 32)) {
+		sr_set_error(r, "truncated BAM record");
+		return -2;
+	}
+	block_size = sr_le_i32(core);
+	ref_id = sr_le_i32(core + 4);
+	pos = sr_le_i32(core + 8);
+	bin_mq_nl = sr_le_u32(core + 12);
+	flag_nc = sr_le_u32(core + 16);
+	l_seq = sr_le_i32(core + 20);
+	if (block_size < 32 || l_seq < 0) {
+		sr_set_error(r, "corrupted BAM record");
+		return -2;
+	}
+	l_read_name = bin_mq_nl & 0xffU;
+	n_cigar = flag_nc & 0xffffU;
+	flag = flag_nc >> 16;
+	data_len = (size_t)block_size - 32;
+	if (r->bam_buf_cap < data_len) {
+		char *tmp = (char *)realloc(r->bam_buf, data_len);
+		if (!tmp) {
+			sr_set_error(r, "out of memory while reading BAM record");
+			return -2;
+		}
+		r->bam_buf = tmp;
+		r->bam_buf_cap = data_len;
+	}
+	if (!sr_gzread_exact(r, r->bam_buf, data_len)) {
+		sr_set_error(r, "truncated BAM payload");
+		return -2;
+	}
+	if (!(flag & 0x4U) || ref_id != -1 || pos != -1 || n_cigar != 0) {
+		sr_set_error(r, "only unaligned BAM input is supported");
+		return -2;
+	}
+	seq_bytes = ((size_t)l_seq + 1) >> 1;
+	qual_off = (size_t)l_read_name + ((size_t)n_cigar << 2) + seq_bytes;
+	if (data_len < qual_off + (size_t)l_seq) {
+		sr_set_error(r, "corrupted BAM read layout");
+		return -2;
+	}
+	if (!sr_reserve(&r->rec.name, l_read_name ? (size_t)l_read_name : 1) ||
+		!sr_reserve(&r->rec.seq, (size_t)l_seq + 1) ||
+		!sr_reserve(&r->rec.qual, (size_t)l_seq + 1)) {
+		sr_set_error(r, "out of memory while decoding BAM read");
+		return -2;
+	}
+	r->rec.name.l = l_read_name ? (size_t)l_read_name - 1 : 0;
+	memcpy(r->rec.name.s, r->bam_buf, r->rec.name.l);
+	r->rec.name.s[r->rec.name.l] = 0;
+	seq = (uint8_t *)r->bam_buf + l_read_name + ((size_t)n_cigar << 2);
+	for (i = 0; i < (size_t)l_seq; ++i) {
+		uint8_t c = seq[i >> 1];
+		r->rec.seq.s[i] = bam_nt16_rev_table[(i & 1)? (c & 0xf) : (c >> 4)];
+	}
+	r->rec.seq.l = (size_t)l_seq;
+	r->rec.seq.s[r->rec.seq.l] = 0;
+	qual = (uint8_t *)r->bam_buf + qual_off;
+	r->rec.qual.l = (size_t)l_seq;
+	for (i = 0; i < (size_t)l_seq; ++i) {
+		if (qual[i] == 0xff) {
+			r->rec.qual.l = 0;
+			break;
+		}
+		r->rec.qual.s[i] = (char)(qual[i] + 33);
+	}
+	if (r->rec.qual.l) r->rec.qual.s[r->rec.qual.l] = 0;
+	return (int)r->rec.seq.l;
+}
+
+int ha_seq_open(ha_seq_reader_t *r, const char *fn)
+{
+	uint8_t magic[4];
+	memset(r, 0, sizeof(*r));
+	r->fp = gzopen(fn, "r");
+	if (!r->fp) {
+		sr_set_error2(r, "failed to open input file: ", fn);
+		return 0;
+	}
+	if (gzread(r->fp, magic, 4) != 4) {
+		sr_set_error2(r, "failed to read input file: ", fn);
+		ha_seq_close(r);
+		return 0;
+	}
+	if (gzrewind(r->fp) != 0) {
+		sr_set_error2(r, "failed to rewind input file: ", fn);
+		ha_seq_close(r);
+		return 0;
+	}
+	if (memcmp(magic, "BAM\1", 4) == 0) {
+		r->mode = HA_SR_BAM;
+		if (!sr_prepare_bam(r)) {
+			if (r->fp) gzclose(r->fp);
+			r->fp = 0;
+			return 0;
+		}
+	} else {
+		r->mode = HA_SR_FASTX;
+		r->ks = kseq_init(r->fp);
+		if (!r->ks) {
+			sr_set_error(r, "failed to initialize FASTA/FASTQ reader");
+			ha_seq_close(r);
+			return 0;
+		}
+	}
+	return 1;
+}
+
+int ha_seq_read(ha_seq_reader_t *r)
+{
+	if (r->mode == HA_SR_BAM) return sr_read_bam(r);
+	if (r->ks) {
+		kseq_t *ks = (kseq_t *)r->ks;
+		int ret = kseq_read(ks);
+		if (ret < 0) return ret;
+		r->rec.name.s = ks->name.s;
+		r->rec.name.l = ks->name.l;
+		r->rec.name.m = ks->name.m;
+		r->rec.seq.s = ks->seq.s;
+		r->rec.seq.l = ks->seq.l;
+		r->rec.seq.m = ks->seq.m;
+		r->rec.qual.s = ks->qual.s;
+		r->rec.qual.l = ks->qual.l;
+		r->rec.qual.m = ks->qual.m;
+		return ret;
+	}
+	sr_set_error(r, "reader is not initialized");
+	return -2;
+}
+
+void ha_seq_close(ha_seq_reader_t *r)
+{
+	if (r->ks) kseq_destroy((kseq_t *)r->ks);
+	if (r->fp) gzclose(r->fp);
+	if (r->mode == HA_SR_BAM) {
+		free(r->rec.name.s);
+		free(r->rec.seq.s);
+		free(r->rec.qual.s);
+	}
+	free(r->bam_buf);
+	r->fp = 0;
+	r->ks = 0;
+	r->bam_buf = 0;
+	r->bam_buf_cap = 0;
+	r->bam_header_ready = 0;
+	r->rec.name.s = r->rec.seq.s = r->rec.qual.s = 0;
+	r->rec.name.l = r->rec.name.m = 0;
+	r->rec.seq.l = r->rec.seq.m = 0;
+	r->rec.qual.l = r->rec.qual.m = 0;
+}
+
+const char *ha_seq_error(const ha_seq_reader_t *r)
+{
+	return r->err;
+}

--- a/seq_reader.cpp
+++ b/seq_reader.cpp
@@ -63,13 +63,12 @@ static int sr_prepare_bam(ha_seq_reader_t *r)
 		sr_set_error(r, "input is not a BAM file");
 		return 0;
 	}
-	if (!sr_gzread_exact(r, hdr, 8)) {
-		sr_set_error(r, "failed to read BAM header");
+	if (!sr_gzread_exact(r, hdr, 4)) {
+		sr_set_error(r, "failed to read BAM header length");
 		return 0;
 	}
 	l_text = sr_le_i32(hdr);
-	n_ref = sr_le_i32(hdr + 4);
-	if (l_text < 0 || n_ref < 0) {
+	if (l_text < 0) {
 		sr_set_error(r, "corrupted BAM header");
 		return 0;
 	}
@@ -87,6 +86,15 @@ static int sr_prepare_bam(ha_seq_reader_t *r)
 			sr_set_error(r, "failed to read BAM text header");
 			return 0;
 		}
+	}
+	if (!sr_gzread_exact(r, hdr, 4)) {
+		sr_set_error(r, "failed to read BAM reference count");
+		return 0;
+	}
+	n_ref = sr_le_i32(hdr);
+	if (n_ref < 0) {
+		sr_set_error(r, "corrupted BAM reference count");
+		return 0;
 	}
 	for (i = 0; i < n_ref; ++i) {
 		int32_t l_name;

--- a/seq_reader.h
+++ b/seq_reader.h
@@ -1,0 +1,38 @@
+#ifndef HAF_SEQ_READER_H
+#define HAF_SEQ_READER_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <zlib.h>
+
+typedef struct {
+	char *s;
+	size_t l, m;
+} ha_sr_buf_t;
+
+typedef struct {
+	ha_sr_buf_t name, seq, qual;
+} ha_sr_rec_t;
+
+typedef enum {
+	HA_SR_FASTX = 0,
+	HA_SR_BAM = 1
+} ha_sr_mode_t;
+
+typedef struct {
+	gzFile fp;
+	void *ks;
+	ha_sr_rec_t rec;
+	ha_sr_mode_t mode;
+	char *bam_buf;
+	size_t bam_buf_cap;
+	char err[256];
+	int bam_header_ready;
+} ha_seq_reader_t;
+
+int ha_seq_open(ha_seq_reader_t *r, const char *fn);
+int ha_seq_read(ha_seq_reader_t *r);
+void ha_seq_close(ha_seq_reader_t *r);
+const char *ha_seq_error(const ha_seq_reader_t *r);
+
+#endif


### PR DESCRIPTION
Response to: [Issue 879](https://github.com/chhylp123/hifiasm/issues/879)

This pull request adds support for native PacBio unaligned bam file format as input without the need to convert to fastq format. 

I ran a test using example PacBio datasets of a Sea Otter. I ran an assembly using the current released version (hifiasm 0.25.0-r726) and then also recompiled hifiasm with the edits made in this pull request and ran assembly again using fastq and unaligned bam file directly. 

Assembly metrics and runtime was equivalent across all three assemblies. 

```
# Download Sea Otter Vega data
wget https://downloads.pacbcloud.com/public/2025Q1/SeaOtter/vega/m21022_241205_234232.hifi_reads.bam
wget https://downloads.pacbcloud.com/public/2025Q1/SeaOtter/vega/m21022_241205_234232.hifi_reads.bam.pbi

# hifiasm 0.25.0-r726
bam2fastq -o m21022_241205_234232.hifi_reads -u -j 16 m21022_241205_234232.hifi_reads.bam
pigz -9 -p 64 m21022_241205_234232.hifi_reads.fastq
hifiasm -o FQ.asm -t 64 m21022_241205_234232.hifi_reads.fastq.gz
gfa2fasta FQ.asm.bp.hap1.p_ctg.gfa 
gfa2fasta FQ.asm.bp.hap2.p_ctg.gfa
gfa2fasta FQ.asm.bp.p_ctg.gfa

# hifiasm 0.25.0-r726 – recompiled with bam support
# Test on same fastq file
./hifiasm/hifiasm -o FQ2.asm -t 64 m21022_241205_234232.hifi_reads.fastq.gz
gfa2fasta FQ2.asm.bp.hap1.p_ctg.gfa 
gfa2fasta FQ2.asm.bp.hap2.p_ctg.gfa
gfa2fasta FQ2.asm.bp.p_ctg.gfa

# hifiasm 0.25.0-r726 – recompiled with bam support
# Test on same corresponding bam file
./hifiasm/hifiasm -o BAM.asm -t 64 m21022_241205_234232.hifi_reads.bam
gfa2fasta BAM.asm.bp.hap1.p_ctg.gfa 
gfa2fasta BAM.asm.bp.hap2.p_ctg.gfa
gfa2fasta BAM.asm.bp.p_ctg.gfa

# Compare stats
seqkit stats -a -j 16 *.fasta
file                         format  type  num_seqs        sum_len  min_len      avg_len      max_len        Q1         Q2         Q3  sum_gap         N50  N50_num  Q20(%)  Q30(%)  AvgQual  GC(%)  sum_n
# hap1
FQ.asm.bp.hap1.p_ctg.fasta   FASTA   DNA        587  2,469,046,954   16,470  4,206,212.9  149,985,306  58,908.5    142,129  501,997.5        0  75,136,325       12       0       0        0  42.15      0
FQ2.asm.bp.hap1.p_ctg.fasta  FASTA   DNA        587  2,469,046,954   16,470  4,206,212.9  149,985,306  58,908.5    142,129  501,997.5        0  75,136,325       12       0       0        0  42.15      0
BAM.asm.bp.hap1.p_ctg.fasta  FASTA   DNA        587  2,469,046,954   16,470  4,206,212.9  149,985,306  58,908.5    142,129  501,997.5        0  75,136,325       12       0       0        0  42.15      0
# hap2
FQ.asm.bp.hap2.p_ctg.fasta   FASTA   DNA        531  2,465,099,682    9,470  4,642,372.3  170,508,645  65,393.5    151,844  458,515.5        0  50,624,205       16       0       0        0  42.07      0
FQ2.asm.bp.hap2.p_ctg.fasta  FASTA   DNA        531  2,465,099,682    9,470  4,642,372.3  170,508,645  65,393.5    151,844  458,515.5        0  50,624,205       16       0       0        0  42.07      0
BAM.asm.bp.hap2.p_ctg.fasta  FASTA   DNA        531  2,465,099,682    9,470  4,642,372.3  170,508,645  65,393.5    151,844  458,515.5        0  50,624,205       16       0       0        0  42.07      0
# primary
FQ.asm.bp.p_ctg.fasta        FASTA   DNA        304  2,515,937,299   13,653  8,276,109.5  209,376,357  68,814.5  185,334.5  550,313.5        0  90,246,494       11       0       0        0  42.29      0
FQ2.asm.bp.p_ctg.fasta       FASTA   DNA        304  2,515,937,299   13,653  8,276,109.5  209,376,357  68,814.5  185,334.5  550,313.5        0  90,246,494       11       0       0        0  42.29      0
BAM.asm.bp.p_ctg.fasta       FASTA   DNA        304  2,515,937,299   13,653  8,276,109.5  209,376,357  68,814.5  185,334.5  550,313.5        0  90,246,494       11       0       0        0  42.29      0


# Original time and memory usage
hifiasm.o55929251:[M::main] Real time: 5194.850 sec; CPU: 199708.479 sec; Peak RSS: 56.487 GB

# Recompiled version fastq test
hifiasm.o55940973:[M::main] Real time: 5380.696 sec; CPU: 213576.435 sec; Peak RSS: 58.941 GB

# Recompiled version bam test
hifiasm.o55940973:[M::main] Real time: 5494.793 sec; CPU: 213867.669 sec; Peak RSS: 57.577 GB
```

Edits to the code were made with Codex v5.4